### PR TITLE
Use SQL-based views for entity CRUD

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,5 +39,8 @@ module.exports = {
 		this.EntityData = require('./models/entityData')(bookshelf);
 		this.Revision = require('./models/revision')(bookshelf);
 		this.EntityRevision = require('./models/entityRevision')(bookshelf);
+
+		this.Creator = require('./models/entities/creator')(bookshelf);
+		this.CreatorType = require('./models/creatorType')(bookshelf);
 	}
 };

--- a/index.js
+++ b/index.js
@@ -42,5 +42,18 @@ module.exports = {
 
 		this.Creator = require('./models/entities/creator')(bookshelf);
 		this.CreatorType = require('./models/creatorType')(bookshelf);
+
+		this.Edition = require('./models/entities/edition')(bookshelf);
+		this.EditionFormat = require('./models/editionFormat')(bookshelf);
+		this.EditionStatus = require('./models/editionStatus')(bookshelf);
+
+		this.Publication = require('./models/entities/publication')(bookshelf);
+		this.PublicationType = require('./models/publicationType')(bookshelf);
+
+		this.Publisher = require('./models/entities/publisher')(bookshelf);
+		this.PublisherType = require('./models/publisherType')(bookshelf);
+
+		this.Work = require('./models/entities/work')(bookshelf);
+		this.WorkType = require('./models/workType')(bookshelf);
 	}
 };

--- a/models/creatorType.js
+++ b/models/creatorType.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2015  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+'use strict';
+
+const util = require('../util');
+
+module.exports = (bookshelf) => {
+	const CreatorType = bookshelf.Model.extend({
+		tableName: 'bookbrainz.creator_type',
+		idAttribute: 'id',
+		parse: util.snakeToCamel,
+		format: util.camelToSnake
+	});
+
+	return bookshelf.model('CreatorType', CreatorType);
+};

--- a/models/editionFormat.js
+++ b/models/editionFormat.js
@@ -21,12 +21,12 @@
 const util = require('../util');
 
 module.exports = (bookshelf) => {
-	const CreatorType = bookshelf.Model.extend({
-		tableName: 'bookbrainz.creator_type',
+	const EditionFormat = bookshelf.Model.extend({
+		tableName: 'bookbrainz.edition_format',
 		idAttribute: 'id',
 		parse: util.snakeToCamel,
 		format: util.camelToSnake
 	});
 
-	return bookshelf.model('CreatorType', CreatorType);
+	return bookshelf.model('EditionFormat', EditionFormat);
 };

--- a/models/editionStatus.js
+++ b/models/editionStatus.js
@@ -21,12 +21,12 @@
 const util = require('../util');
 
 module.exports = (bookshelf) => {
-	const CreatorType = bookshelf.Model.extend({
-		tableName: 'bookbrainz.creator_type',
+	const EditionStatus = bookshelf.Model.extend({
+		tableName: 'bookbrainz.edition_status',
 		idAttribute: 'id',
 		parse: util.snakeToCamel,
 		format: util.camelToSnake
 	});
 
-	return bookshelf.model('CreatorType', CreatorType);
+	return bookshelf.model('EditionStatus', EditionStatus);
 };

--- a/models/entities/creator.js
+++ b/models/entities/creator.js
@@ -18,8 +18,9 @@
 
 'use strict';
 
-const validateEntityType = require('../../utils').validateEntityType;
 const _ = require('lodash');
+
+const util = require('../../util');
 
 module.exports = (bookshelf) => {
 	const Entity = bookshelf.model('Entity');
@@ -27,8 +28,24 @@ module.exports = (bookshelf) => {
 	const CreatorData = bookshelf.model('CreatorData');
 
 	const Creator = Entity.extend({
-		initialize(attributes) {
-			this.on('fetched', validateEntityType.bind(this));
+		tableName: 'bookbrainz.creator',
+		idAttribute: 'bbid',
+		parse: util.snakeToCamel,
+		format: util.camelToSnake,
+		gender() {
+			return this.belongsTo('Gender', 'gender_id');
+		},
+		creatorType() {
+			return this.belongsTo('CreatorType', 'creator_type_id');
+		},
+		defaultAlias() {
+			return this.belongsTo('Alias', 'default_alias_id');
+		},
+		disambiguation() {
+			return this.belongsTo('Disambiguation', 'disambiguation_id');
+		},
+		annotation() {
+			return this.belongsTo('Annotation', 'annotation_id');
 		},
 		create(data) {
 			// Create Creator
@@ -65,8 +82,7 @@ module.exports = (bookshelf) => {
 						{masterRevisionId: revisionId}
 					);
 				});
-		},
-		typeId: 'Creator'
+		}
 	});
 
 	return bookshelf.model('Creator', Creator);

--- a/models/entities/creatorData.js
+++ b/models/entities/creatorData.js
@@ -30,26 +30,6 @@ module.exports = (bookshelf) => {
 			return this.morphOne(
 				'EntityData', 'entity_data', ['_type', 'id'], '1'
 			);
-		},
-		create(data) {
-			const beginDate = util.parseDate(data.beginDate);
-			const endDate = util.parseDate(data.endDate);
-
-			const entityData = _.pluck(
-				data, ['annotation', 'disambiguation', 'aliases']
-			);
-			EntityData.create(entityData);
-
-			this.save({
-				beginDate: beginDate.fullDate,
-				beginDatePrecision: beginDate.precision,
-				endDate: endDate.fullDate,
-				endDatePrecision: endDate.precision,
-				ended: data.ended,
-				countryId: data.country,
-				genderId: data.gender,
-				creatorTypeId: data.creatorType
-			});
 		}
 	});
 

--- a/models/entities/edition.js
+++ b/models/entities/edition.js
@@ -1,5 +1,4 @@
 /*
- * Copyright (C) 2015  Ben Ockmore
  * Copyright (C) 2015  Sean Burke
  *
  * This program is free software; you can redistribute it and/or modify
@@ -24,16 +23,25 @@ const util = require('../../util');
 module.exports = (bookshelf) => {
 	const Entity = bookshelf.model('Entity');
 
-	const Creator = Entity.extend({
-		tableName: 'bookbrainz.creator',
+	const Edition = Entity.extend({
+		tableName: 'bookbrainz.edition',
 		idAttribute: 'bbid',
 		parse: util.snakeToCamel,
 		format: util.camelToSnake,
-		gender() {
-			return this.belongsTo('Gender', 'gender_id');
+		publication() {
+			return this.belongsTo('Publication', 'publication_bbid');
 		},
-		creatorType() {
-			return this.belongsTo('CreatorType', 'creator_type_id');
+		language() {
+			return this.belongsTo('Language', 'language_id');
+		},
+		editionFormat() {
+			return this.belongsTo('EditionFormat', 'edition_format_id');
+		},
+		editionStatus() {
+			return this.belongsTo('EditionStatus', 'edition_status_id');
+		},
+		publisher() {
+			return this.belongsTo('Publisher', 'publisher_id');
 		},
 		defaultAlias() {
 			return this.belongsTo('Alias', 'default_alias_id');
@@ -46,5 +54,5 @@ module.exports = (bookshelf) => {
 		}
 	});
 
-	return bookshelf.model('Creator', Creator);
+	return bookshelf.model('Edition', Edition);
 };

--- a/models/entities/publication.js
+++ b/models/entities/publication.js
@@ -18,15 +18,29 @@
 
 'use strict';
 
-const util = require('../util');
+const util = require('../../util');
 
 module.exports = (bookshelf) => {
-	const CreatorType = bookshelf.Model.extend({
-		tableName: 'bookbrainz.creator_type',
-		idAttribute: 'id',
+	const Entity = bookshelf.model('Entity');
+
+	const Publication = Entity.extend({
+		tableName: 'bookbrainz.publication',
+		idAttribute: 'bbid',
 		parse: util.snakeToCamel,
-		format: util.camelToSnake
+		format: util.camelToSnake,
+		publicationType() {
+			return this.belongsTo('PublicationType', 'publication_type_id');
+		},
+		defaultAlias() {
+			return this.belongsTo('Alias', 'default_alias_id');
+		},
+		disambiguation() {
+			return this.belongsTo('Disambiguation', 'disambiguation_id');
+		},
+		annotation() {
+			return this.belongsTo('Annotation', 'annotation_id');
+		}
 	});
 
-	return bookshelf.model('CreatorType', CreatorType);
+	return bookshelf.model('Publication', Publication);
 };

--- a/models/entities/publisher.js
+++ b/models/entities/publisher.js
@@ -18,15 +18,29 @@
 
 'use strict';
 
-const util = require('../util');
+const util = require('../../util');
 
 module.exports = (bookshelf) => {
-	const CreatorType = bookshelf.Model.extend({
-		tableName: 'bookbrainz.creator_type',
-		idAttribute: 'id',
+	const Entity = bookshelf.model('Entity');
+
+	const Publisher = Entity.extend({
+		tableName: 'bookbrainz.publisher',
+		idAttribute: 'bbid',
 		parse: util.snakeToCamel,
-		format: util.camelToSnake
+		format: util.camelToSnake,
+		publisherType() {
+			return this.belongsTo('PublisherType', 'publisher_type_id');
+		},
+		defaultAlias() {
+			return this.belongsTo('Alias', 'default_alias_id');
+		},
+		disambiguation() {
+			return this.belongsTo('Disambiguation', 'disambiguation_id');
+		},
+		annotation() {
+			return this.belongsTo('Annotation', 'annotation_id');
+		}
 	});
 
-	return bookshelf.model('CreatorType', CreatorType);
+	return bookshelf.model('Publisher', Publisher);
 };

--- a/models/entities/work.js
+++ b/models/entities/work.js
@@ -18,15 +18,29 @@
 
 'use strict';
 
-const util = require('../util');
+const util = require('../../util');
 
 module.exports = (bookshelf) => {
-	const CreatorType = bookshelf.Model.extend({
-		tableName: 'bookbrainz.creator_type',
-		idAttribute: 'id',
+	const Entity = bookshelf.model('Entity');
+
+	const Work = Entity.extend({
+		tableName: 'bookbrainz.work',
+		idAttribute: 'bbid',
 		parse: util.snakeToCamel,
-		format: util.camelToSnake
+		format: util.camelToSnake,
+		workType() {
+			return this.belongsTo('WorkType', 'work_type_id');
+		},
+		defaultAlias() {
+			return this.belongsTo('Alias', 'default_alias_id');
+		},
+		disambiguation() {
+			return this.belongsTo('Disambiguation', 'disambiguation_id');
+		},
+		annotation() {
+			return this.belongsTo('Annotation', 'annotation_id');
+		}
 	});
 
-	return bookshelf.model('CreatorType', CreatorType);
+	return bookshelf.model('Work', Work);
 };

--- a/models/entity.js
+++ b/models/entity.js
@@ -28,15 +28,6 @@ module.exports = (bookshelf) => {
 		format: util.camelToSnake,
 		masterRevision() {
 			return this.belongsTo('Revision', 'master_revision_id');
-		},
-		create() {
-			throw new Error('Not implemented for base Entity');
-		},
-		update() {
-			throw new Error('Not implemented for base Entity');
-		},
-		destroy() {
-			throw new Error('Not implemented for base Entity');
 		}
 	});
 

--- a/models/entityData.js
+++ b/models/entityData.js
@@ -21,10 +21,6 @@
 const util = require('../util');
 
 module.exports = (bookshelf) => {
-	const Alias = bookshelf.model('Alias');
-	const Annotation = bookshelf.model('Annotation');
-	const Disambiguation = bookshelf.model('Disambiguation');
-
 	const EntityData = bookshelf.Model.extend({
 		tableName: 'bookbrainz.entity_data',
 		idAttribute: 'id',
@@ -32,30 +28,6 @@ module.exports = (bookshelf) => {
 		format: util.camelToSnake,
 		defaultAlias() {
 			return this.belongsTo('Alias', 'default_alias_id');
-		},
-		create(data) {
-			const annotationPromise =
-				new Annotation({content: data.annotation}).save();
-			const disambiguationPromise =
-				new Disambiguation({comment: data.disambiguation}).save();
-			const aliasesPromise = Promise.all(data.aliases.map((alias) => {
-				return new Alias({
-					name: alias.name, sortName: alias.sortName,
-					languageId: alias.language, primary: alias.primary
-				}).save();
-			}));
-
-			return Promise.join(
-				annotationPromise, disambiguationPromise, aliasesPromise,
-				(annotation, disambiguation, aliases) => {
-					const entityData = new EntityData({
-						annotationId: annotation.get('id'),
-						disambiguationId: disambiguation.get('id')
-					});
-					return entityData;
-					// Link aliases to entity data
-				}
-			);
 		}
 	});
 

--- a/models/entityRevision.js
+++ b/models/entityRevision.js
@@ -18,13 +18,9 @@
 
 'use strict';
 
-const _ = require('lodash');
-
 const util = require('../util');
 
 module.exports = (bookshelf) => {
-	const Revision = bookshelf.model('Revision');
-
 	const EntityRevision = bookshelf.Model.extend({
 		tableName: 'bookbrainz.entity_revision',
 		idAttribute: 'id',
@@ -40,21 +36,6 @@ module.exports = (bookshelf) => {
 		},
 		entityData() {
 			return this.belongsTo('EntityData', 'entity_data_id');
-		},
-		create(attribs) {
-			const self = this;
-			const revisionAttribs =
-				_.pick(attribs, 'id', 'authorId', 'parentId');
-			revisionAttribs._type = 1;
-
-			const entityRevisionAttribs =
-				_.pick(attribs, 'id', 'entityBbid', 'entityDataId');
-
-			return new Revision(revisionAttribs)
-			.save(null, {method: 'insert'})
-			.then(
-				() => self.save(entityRevisionAttribs, {method: 'insert'})
-			);
 		}
 	});
 

--- a/models/publicationType.js
+++ b/models/publicationType.js
@@ -21,12 +21,12 @@
 const util = require('../util');
 
 module.exports = (bookshelf) => {
-	const CreatorType = bookshelf.Model.extend({
-		tableName: 'bookbrainz.creator_type',
+	const PublicationType = bookshelf.Model.extend({
+		tableName: 'bookbrainz.publication_type',
 		idAttribute: 'id',
 		parse: util.snakeToCamel,
 		format: util.camelToSnake
 	});
 
-	return bookshelf.model('CreatorType', CreatorType);
+	return bookshelf.model('PublicationType', PublicationType);
 };

--- a/models/publisherType.js
+++ b/models/publisherType.js
@@ -21,12 +21,12 @@
 const util = require('../util');
 
 module.exports = (bookshelf) => {
-	const CreatorType = bookshelf.Model.extend({
-		tableName: 'bookbrainz.creator_type',
+	const PublisherType = bookshelf.Model.extend({
+		tableName: 'bookbrainz.publisher_type',
 		idAttribute: 'id',
 		parse: util.snakeToCamel,
 		format: util.camelToSnake
 	});
 
-	return bookshelf.model('CreatorType', CreatorType);
+	return bookshelf.model('PublisherType', PublisherType);
 };

--- a/models/workType.js
+++ b/models/workType.js
@@ -21,12 +21,12 @@
 const util = require('../util');
 
 module.exports = (bookshelf) => {
-	const CreatorType = bookshelf.Model.extend({
-		tableName: 'bookbrainz.creator_type',
+	const WorkType = bookshelf.Model.extend({
+		tableName: 'bookbrainz.work_type',
 		idAttribute: 'id',
 		parse: util.snakeToCamel,
 		format: util.camelToSnake
 	});
 
-	return bookshelf.model('CreatorType', CreatorType);
+	return bookshelf.model('WorkType', WorkType);
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bookbrainz-data",
   "version": "0.2.0",
-  "description": "The ORM to facilitate access to the BookBrainz database.",
+  "description": "A JavaScript data access module for BookBrainz",
   "main": "index.js",
   "scripts": {
     "test": "./check-style.sh && istanbul cover _mocha"

--- a/test/testEntity.js
+++ b/test/testEntity.js
@@ -69,7 +69,7 @@ describe('Entity model', () => {
 			bbid: '68f52341-eea4-4ebc-9a15-6226fb68962c',
 			masterRevisionId: null, _type: 'Creator'
 		};
-		const entityDataAttribs = {id: 1, _type: 2};
+		const entityDataAttribs = {id: 1, _type: 'Creator'};
 		const revisionAttribs = {id: 1, authorId: 1, _type: 1};
 		const entityRevisionAttribs = {
 			id: 1, entityBbid: '68f52341-eea4-4ebc-9a15-6226fb68962c',

--- a/test/testEntityRevision.js
+++ b/test/testEntityRevision.js
@@ -22,7 +22,6 @@ const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const expect = chai.expect;
 const Promise = require('bluebird');
-const _ = require('lodash');
 
 const Bookshelf = require('./bookshelf');
 
@@ -93,42 +92,4 @@ describe('EntityRevision model', () => {
 			'entityBbid', 'id', 'entityDataId', 'entity', 'revision'
 		]);
 	});
-
-	it('the create method should result in a new revision and EntityRevision',
-		() => {
-			const entityRevisionAttribs = {
-				id: 1, entityBbid: '68f52341-eea4-4ebc-9a15-6226fb68962c'
-			};
-
-			const combinedAttributes =
-				_.assign(_.clone(entityRevisionAttribs), revisionAttribs);
-
-			delete combinedAttributes._type;
-
-			const entityRevisionPromise = new EntityRevision()
-				.create(combinedAttributes)
-				.then((model) =>
-					model.refresh({
-						withRelated: ['entity', 'entityData', 'revision']
-					})
-				)
-				.then((revision) => revision.toJSON());
-
-			return Promise.all([
-				expect(entityRevisionPromise).to.eventually
-					.have.property('id', 1),
-				expect(entityRevisionPromise).to.eventually.have
-					.property(
-						'entityBbid',
-						'68f52341-eea4-4ebc-9a15-6226fb68962c'
-					),
-				expect(entityRevisionPromise).to.eventually
-					.have.deep.property('revision.id', 1),
-				expect(entityRevisionPromise).to.eventually
-					.have.deep.property('revision._type', 1),
-				expect(entityRevisionPromise).to.eventually
-					.have.deep.property('revision.authorId', 1)
-			]);
-		}
-	);
 });


### PR DESCRIPTION
This removes the current custom methods for insert, update and delete and relation-based fetching of data in favor of using views defined in SQL which automatically do the right thing when passed a composed entity object.

Basic read testing has been done, with insert/update/delete testing done at the SQL level only. Also missing unit tests for the moment.