### PR TITLE
Hook in modified schema for edition/work properties

### DIFF
--- a/models/data/editionData.js
+++ b/models/data/editionData.js
@@ -46,7 +46,7 @@ module.exports = (bookshelf) => {
 			return this.belongsTo('Publication', 'publication_bbid');
 		},
 		publisherSet() {
-			return this.belongsTo('Publisher', 'publisher_set_id');
+			return this.belongsTo('PublisherSet', 'publisher_set_id');
 		},
 		editionStatus() {
 			return this.belongsTo('EditionStatus', 'status_id');

--- a/models/data/editionData.js
+++ b/models/data/editionData.js
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2016  Ben Ockmore
+ *           (C) 2016       Sean Burke
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -45,10 +46,7 @@ module.exports = (bookshelf) => {
 			return this.belongsTo('Publication', 'publication_bbid');
 		},
 		publishers() {
-			return this.belongsToMany(
-				'Publisher', 'bookbrainz.edition_data__publisher', 'data_id',
-				'publisher_bbid'
-			);
+			return this.belongsTo('Publisher', 'publisher_set_id');
 		},
 		editionStatus() {
 			return this.belongsTo('EditionStatus', 'status_id');
@@ -57,16 +55,10 @@ module.exports = (bookshelf) => {
 			return this.belongsTo('EditionFormat', 'format_id');
 		},
 		releaseEvents() {
-			return this.belongsToMany(
-				'ReleaseEvent', 'bookbrainz.edition_data__release_event',
-				'edition_data_id', 'release_event_id'
-			);
+			return this.belongsTo('ReleaseEventSet', 'release_event_set_id');
 		},
 		languages() {
-			return this.belongsToMany(
-				'Language', 'bookbrainz.edition_data__language',
-				'data_id', 'language_id'
-			);
+			return this.belongsTo('LanguageSet', 'language_set_id');
 		}
 	});
 

--- a/models/data/editionData.js
+++ b/models/data/editionData.js
@@ -45,7 +45,7 @@ module.exports = (bookshelf) => {
 		publication() {
 			return this.belongsTo('Publication', 'publication_bbid');
 		},
-		publishers() {
+		publisherSet() {
 			return this.belongsTo('Publisher', 'publisher_set_id');
 		},
 		editionStatus() {
@@ -54,10 +54,10 @@ module.exports = (bookshelf) => {
 		editionFormat() {
 			return this.belongsTo('EditionFormat', 'format_id');
 		},
-		releaseEvents() {
+		releaseEventSet() {
 			return this.belongsTo('ReleaseEventSet', 'release_event_set_id');
 		},
-		languages() {
+		languageSet() {
 			return this.belongsTo('LanguageSet', 'language_set_id');
 		}
 	});

--- a/models/data/publicationData.js
+++ b/models/data/publicationData.js
@@ -45,7 +45,8 @@ module.exports = (bookshelf) => {
 			return this.belongsTo('PublicationType', 'type_id');
 		},
 		editions() {
-			return this.hasMany('Edition', 'publication_bbid');
+			return this.hasMany('Edition', 'publication_bbid')
+				.query({where: {master: true}});
 		}
 	});
 

--- a/models/data/publisherData.js
+++ b/models/data/publisherData.js
@@ -44,13 +44,27 @@ module.exports = (bookshelf) => {
 		publisherType() {
 			return this.belongsTo('PublisherType', 'type_id');
 		},
-		editions() {
-			return this.belongsToMany(
-				'Edition',
-				'bookbrainz.edition_data__publisher',
-				'publisher_bbid',
-				'publisher_bbid'
-			);
+		editions(options) {
+			const Edition = bookshelf.model('Edition');
+			const bbid = this.get('bbid');
+			return Edition.query((qb) => {
+				qb
+					.leftJoin(
+						'bookbrainz.publisher_set',
+						'bookbrainz.edition.publisher_set_id',
+						'bookbrainz.publisher_set.id'
+					)
+					.rightJoin(
+						'bookbrainz.publisher_set__publisher',
+						'bookbrainz.publisher_set.id',
+						'bookbrainz.publisher_set__publisher.set_id'
+					)
+					.where({
+						'bookbrainz.edition.master': true,
+						'bookbrainz.publisher_set__publisher.publisher_bbid':
+							bbid
+					});
+			}).fetchAll(options);
 		},
 		virtuals: {
 			beginDate: {

--- a/models/data/workData.js
+++ b/models/data/workData.js
@@ -42,7 +42,7 @@ module.exports = (bookshelf) => {
 		identifierSet() {
 			return this.belongsTo('IdentifierSet', 'identifier_set_id');
 		},
-		languages() {
+		languageSet() {
 			return this.belongsTo('LanguageSet', 'language_set_id');
 		},
 		workType() {

--- a/models/data/workData.js
+++ b/models/data/workData.js
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2016  Ben Ockmore
+ *           (C) 2016       Sean Burke
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -42,12 +43,7 @@ module.exports = (bookshelf) => {
 			return this.belongsTo('IdentifierSet', 'identifier_set_id');
 		},
 		languages() {
-			return this.belongsToMany(
-				'Language',
-				'bookbrainz.work_data__language',
-				'data_id',
-				'language_id'
-			);
+			return this.belongsTo('LanguageSet', 'language_set_id');
 		},
 		workType() {
 			return this.belongsTo('WorkType', 'type_id');

--- a/models/entities/creator.js
+++ b/models/entities/creator.js
@@ -37,9 +37,6 @@ module.exports = (bookshelf) => {
 				options.query.where({master: true});
 			});
 		},
-		data() {
-			return this.belongsTo('CreatorData', 'data_id');
-		},
 		defaultAlias() {
 			return this.belongsTo('Alias', 'default_alias_id');
 		},

--- a/models/entities/edition.js
+++ b/models/entities/edition.js
@@ -37,9 +37,6 @@ module.exports = (bookshelf) => {
 				options.query.where({master: true});
 			});
 		},
-		data() {
-			return this.belongsTo('EditionData', 'data_id');
-		},
 		defaultAlias() {
 			return this.belongsTo('Alias', 'default_alias_id');
 		},

--- a/models/entities/publication.js
+++ b/models/entities/publication.js
@@ -37,9 +37,6 @@ module.exports = (bookshelf) => {
 				options.query.where({master: true});
 			});
 		},
-		data() {
-			return this.belongsTo('PublicationData', 'data_id');
-		},
 		defaultAlias() {
 			return this.belongsTo('Alias', 'default_alias_id');
 		},

--- a/models/entities/publisher.js
+++ b/models/entities/publisher.js
@@ -37,9 +37,6 @@ module.exports = (bookshelf) => {
 				options.query.where({master: true});
 			});
 		},
-		data() {
-			return this.belongsTo('PublisherData', 'data_id');
-		},
 		defaultAlias() {
 			return this.belongsTo('Alias', 'default_alias_id');
 		},

--- a/models/entities/work.js
+++ b/models/entities/work.js
@@ -37,9 +37,6 @@ module.exports = (bookshelf) => {
 				options.query.where({master: true});
 			});
 		},
-		data() {
-			return this.belongsTo('WorkData', 'data_id');
-		},
 		defaultAlias() {
 			return this.belongsTo('Alias', 'default_alias_id');
 		},

--- a/models/languageSet.js
+++ b/models/languageSet.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016  Sean Burke
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+'use strict';
+
+const util = require('../util');
+
+module.exports = (bookshelf) => {
+	const LanguageSet = bookshelf.Model.extend({
+		tableName: 'bookbrainz.language_set',
+		idAttribute: 'id',
+		parse: util.snakeToCamel,
+		format: util.camelToSnake,
+		relationships() {
+			return this.belongsToMany(
+				'Language', 'bookbrainz.language_set__language',
+				'set_id', 'language_id'
+			);
+		}
+	});
+
+	return bookshelf.model('LanguageSet', LanguageSet);
+};

--- a/models/languageSet.js
+++ b/models/languageSet.js
@@ -26,7 +26,7 @@ module.exports = (bookshelf) => {
 		idAttribute: 'id',
 		parse: util.snakeToCamel,
 		format: util.camelToSnake,
-		relationships() {
+		languages() {
 			return this.belongsToMany(
 				'Language', 'bookbrainz.language_set__language',
 				'set_id', 'language_id'

--- a/models/publisherSet.js
+++ b/models/publisherSet.js
@@ -26,7 +26,7 @@ module.exports = (bookshelf) => {
 		idAttribute: 'id',
 		parse: util.snakeToCamel,
 		format: util.camelToSnake,
-		relationships() {
+		publishers() {
 			return this.belongsToMany(
 				'Publisher', 'bookbrainz.publisher_set__publisher',
 				'set_id', 'publisher_bbid'

--- a/models/publisherSet.js
+++ b/models/publisherSet.js
@@ -30,7 +30,7 @@ module.exports = (bookshelf) => {
 			return this.belongsToMany(
 				'Publisher', 'bookbrainz.publisher_set__publisher',
 				'set_id', 'publisher_bbid'
-			);
+			).query({where: {master: true}});
 		}
 	});
 

--- a/models/publisherSet.js
+++ b/models/publisherSet.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016  Sean Burke
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+'use strict';
+
+const util = require('../util');
+
+module.exports = (bookshelf) => {
+	const PublisherSet = bookshelf.Model.extend({
+		tableName: 'bookbrainz.publisher_set',
+		idAttribute: 'id',
+		parse: util.snakeToCamel,
+		format: util.camelToSnake,
+		relationships() {
+			return this.belongsToMany(
+				'Publisher', 'bookbrainz.publisher_set__publisher',
+				'set_id', 'publisher_bbid'
+			);
+		}
+	});
+
+	return bookshelf.model('PublisherSet', PublisherSet);
+};

--- a/models/releaseEventSet.js
+++ b/models/releaseEventSet.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016  Sean Burke
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+'use strict';
+
+const util = require('../util');
+
+module.exports = (bookshelf) => {
+	const ReleaseEventSet = bookshelf.Model.extend({
+		tableName: 'bookbrainz.release_event_set',
+		idAttribute: 'id',
+		parse: util.snakeToCamel,
+		format: util.camelToSnake,
+		relationships() {
+			return this.belongsToMany(
+				'ReleaseEvent', 'bookbrainz.release_event_set__release_event',
+				'set_id', 'release_event_id'
+			);
+		}
+	});
+
+	return bookshelf.model('ReleaseEventSet', ReleaseEventSet);
+};

--- a/models/releaseEventSet.js
+++ b/models/releaseEventSet.js
@@ -26,7 +26,7 @@ module.exports = (bookshelf) => {
 		idAttribute: 'id',
 		parse: util.snakeToCamel,
 		format: util.camelToSnake,
-		relationships() {
+		releaseEvents() {
 			return this.belongsToMany(
 				'ReleaseEvent', 'bookbrainz.release_event_set__release_event',
 				'set_id', 'release_event_id'

--- a/models/revisions/editionRevision.js
+++ b/models/revisions/editionRevision.js
@@ -40,9 +40,10 @@ module.exports = (bookshelf) => {
 				'annotation', 'disambiguation', 'aliasSet.aliases',
 				'aliasSet.defaultAlias',
 				'relationshipSet.relationships',
-				'relationshipSet.relationships.type', 'publishers',
+				'relationshipSet.relationships.type', 'publisherSet.publishers',
 				'publication', 'editionFormat', 'editionStatus',
-				'releaseEvents', 'identifierSet.identifiers.type', 'languages'
+				'releaseEventSet.releaseEvents', 'languageSet.languages',
+				'identifierSet.identifiers.type'
 			]);
 		},
 		parent() {

--- a/models/revisions/workRevision.js
+++ b/models/revisions/workRevision.js
@@ -40,7 +40,8 @@ module.exports = (bookshelf) => {
 				'annotation', 'disambiguation', 'aliasSet.aliases',
 				'aliasSet.defaultAlias', 'identifierSet.identifiers',
 				'relationshipSet.relationships.type',
-				'workType', 'languages', 'identifierSet.identifiers.type'
+				'workType', 'languageSet.languages',
+				'identifierSet.identifiers.type'
 			]);
 		},
 		parent() {


### PR DESCRIPTION
This pulls in the schema changes in https://github.com/bookbrainz/bookbrainz-sql/pull/2, provides models for them, and uses those models in building relations on Edition and Work entities.