### PR TITLE
Fix tests depending on Editor password

### DIFF
--- a/test/testAchievementUnlock.js
+++ b/test/testAchievementUnlock.js
@@ -39,7 +39,6 @@ describe('AchievementUnlock model', () => {
 	const editorAttribs = {
 		id: 1,
 		name: 'bob',
-		password: 'test',
 		genderId: 1,
 		typeId: 1
 	};

--- a/test/testAnnotation.js
+++ b/test/testAnnotation.js
@@ -38,7 +38,6 @@ const editorTypeAttribs = {
 const editorAttribs = {
 	id: 1,
 	name: 'bob',
-	password: 'test',
 	genderId: 1,
 	typeId: 1
 };

--- a/test/testCreator.js
+++ b/test/testCreator.js
@@ -49,7 +49,6 @@ const editorTypeData = {
 const editorAttribs = {
 	id: 1,
 	name: 'bob',
-	password: 'test',
 	genderId: 1,
 	typeId: 1
 };

--- a/test/testEdition.js
+++ b/test/testEdition.js
@@ -49,7 +49,6 @@ const editorTypeData = {
 const editorAttribs = {
 	id: 1,
 	name: 'bob',
-	password: 'test',
 	genderId: 1,
 	typeId: 1
 };

--- a/test/testEditionRevision.js
+++ b/test/testEditionRevision.js
@@ -51,7 +51,6 @@ const data = {
 	editor: {
 		id: 1,
 		name: 'bob',
-		password: 'test',
 		genderId: 1,
 		typeId: 1
 	},

--- a/test/testEditor.js
+++ b/test/testEditor.js
@@ -24,7 +24,6 @@ chai.use(chaiAsPromised);
 const expect = chai.expect;
 
 const _ = require('lodash');
-const Promise = require('bluebird');
 
 const util = require('../util');
 const Bookshelf = require('./bookshelf');

--- a/test/testEditor.js
+++ b/test/testEditor.js
@@ -46,7 +46,6 @@ const editorTypeAttribs = {
 const editorAttribs = {
 	id: 1,
 	name: 'bob',
-	password: 'test',
 	genderId: 1,
 	typeId: 1
 };
@@ -102,65 +101,9 @@ describe('Editor model', () => {
 		return expect(editorPromise).to.eventually.have.all.keys([
 			'id', 'name', 'reputation', 'bio', 'birthDate',
 			'createdAt', 'activeAt', 'typeId', 'gender', 'genderId',
-			'areaId', 'password', 'revisionsApplied', 'revisionsReverted',
+			'areaId', 'revisionsApplied', 'revisionsReverted',
 			'totalRevisions', 'type', 'revisions', 'titleUnlockId',
 			'metabrainzUserId', 'cachedMetabrainzName'
 		]);
-	});
-
-	it('should hash passwords for new editors', () => {
-		const editorPromise = new Editor(editorAttribs)
-			.save(null, {method: 'insert'})
-			.then(() => new Editor({id: 1}).fetch({require: true}))
-			.then((editor) => editor.get('password'));
-
-		return Promise.all([
-			expect(editorPromise).to.eventually.not.equal('test'),
-			expect(editorPromise).to.eventually.match(/^[.\/$A-Za-z0-9]{60}$/)
-		]);
-	});
-
-	it('should hash updated passwords', () => {
-		let hashed;
-
-		const editorPromise = new Editor(editorAttribs)
-			.save(null, {method: 'insert'})
-			.then(() => new Editor({id: 1}).fetch({require: true}))
-			.then((editor) => {
-				hashed = editor.get('password');
-				editor.set('password', 'orange');
-
-				return editor.save();
-			})
-			.then(() => new Editor({id: 1}).fetch({require: true}))
-			.then((editor) => editor.get('password'));
-
-		return Promise.all([
-			expect(editorPromise).to.eventually.not.equal('orange'),
-			expect(editorPromise).to.eventually.not.equal(hashed),
-			expect(editorPromise).to.eventually.match(/^[.\/$A-Za-z0-9]{60}$/)
-		]);
-	});
-
-	it('should distinguish correct and incorrect passwords', () => {
-		const editorPromise = new Editor(editorAttribs)
-			.save(null, {method: 'insert'})
-			.then(() =>
-				new Editor({id: 1})
-					.fetch({require: true})
-			)
-			.then((editor) =>
-				[
-					editor.checkPassword('test'),
-					editor.checkPassword('orange')
-				]
-			);
-
-		return editorPromise.spread((correct, incorrect) =>
-			Promise.all([
-				expect(correct).to.equal(true),
-				expect(incorrect).to.equal(false)
-			])
-		);
 	});
 });

--- a/test/testEditorEntityVisits.js
+++ b/test/testEditorEntityVisits.js
@@ -49,7 +49,6 @@ const editorTypeData = {
 const editorData = {
 	id: 1,
 	name: 'bob',
-	password: 'test',
 	genderId: 1,
 	typeId: 1
 };

--- a/test/testPublication.js
+++ b/test/testPublication.js
@@ -49,7 +49,6 @@ const editorTypeData = {
 const editorAttribs = {
 	id: 1,
 	name: 'bob',
-	password: 'test',
 	genderId: 1,
 	typeId: 1
 };

--- a/test/testPublisher.js
+++ b/test/testPublisher.js
@@ -49,7 +49,6 @@ const editorTypeData = {
 const editorAttribs = {
 	id: 1,
 	name: 'bob',
-	password: 'test',
 	genderId: 1,
 	typeId: 1
 };

--- a/test/testRevision.js
+++ b/test/testRevision.js
@@ -38,7 +38,6 @@ describe('Revision model', () => {
 	const editorAttribs = {
 		id: 1,
 		name: 'bob',
-		password: 'test',
 		genderId: 1,
 		typeId: 1
 	};

--- a/test/testTitleUnlock.js
+++ b/test/testTitleUnlock.js
@@ -40,7 +40,6 @@ describe('TitleUnlock model', () => {
 	const editorAttribs = {
 		id: 1,
 		name: 'bob',
-		password: 'test',
 		genderId: 1,
 		typeId: 1
 	};

--- a/test/testWork.js
+++ b/test/testWork.js
@@ -49,7 +49,6 @@ const editorTypeData = {
 const editorData = {
 	id: 1,
 	name: 'bob',
-	password: 'test',
 	genderId: 1,
 	typeId: 1
 };


### PR DESCRIPTION
The `Editor` table no longer has a password field, but tests depending on having an editor in the database still attempt to create one, and the `Editor` model tests still test for password behavior. This breaks CI.
