### PR TITLE
Added area relations to Editor, Creator, and Publisher entity models

### DIFF
--- a/models/data/creatorData.js
+++ b/models/data/creatorData.js
@@ -47,6 +47,12 @@ module.exports = (bookshelf) => {
 		creatorType() {
 			return this.belongsTo('CreatorType', 'type_id');
 		},
+		beginArea() {
+			return this.belongsTo('Area', 'begin_area_id');
+		},
+		endArea() {
+			return this.belongsTo('Area', 'end_area_id');
+		},
 		virtuals: {
 			beginDate: {
 				get() {

--- a/models/data/publisherData.js
+++ b/models/data/publisherData.js
@@ -44,6 +44,9 @@ module.exports = (bookshelf) => {
 		publisherType() {
 			return this.belongsTo('PublisherType', 'type_id');
 		},
+		area() {
+			return this.belongsTo('Area', 'area_id');
+		},
 		editions(options) {
 			const Edition = bookshelf.model('Edition');
 			const bbid = this.get('bbid');

--- a/models/editor.js
+++ b/models/editor.js
@@ -44,6 +44,9 @@ module.exports = (bookshelf) => {
 		incrementEditCount() {
 			this.set('totalRevisions', this.get('totalRevisions') + 1);
 			this.set('revisionsApplied', this.get('revisionsApplied') + 1);
+		},
+		area() {
+			return this.belongsTo('Area', 'area_id');
 		}
 	});
 


### PR DESCRIPTION
This PR adds area relations to the following bookshelf entity models:
- Editor
- Creator
- Publisher

Following this change, UI for editing these area fields will be exposed on the bookbrainz site.