### PR TITLE
Add queries to extract the most recent entity type revisions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -121,6 +121,7 @@ export default function init(config) {
 		IdentifierType: identifierType(bookshelf),
 		Language: language(bookshelf),
 		LanguageSet: languageSet(bookshelf),
+		MapRevisionsToAlias: revision.mapRevisionsToAlias(bookshelf),
 		Note: note(bookshelf),
 		Publication: publication(bookshelf),
 		PublicationData,

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+import * as entity from './models/entity';
 import * as revision from './models/revision';
 import * as util from './util'; // eslint-disable-line import/no-namespace
 
@@ -41,7 +42,6 @@ import editionStatus from './models/editionStatus';
 import editor from './models/editor';
 import editorEntityVisits from './models/editorEntityVisits';
 import editorType from './models/editorType';
-import entity from './models/entity';
 import gender from './models/gender';
 import identifier from './models/identifier';
 import identifierSet from './models/identifierSet';
@@ -114,7 +114,7 @@ export default function init(config) {
 		Editor: editor(bookshelf),
 		EditorEntityVisits: editorEntityVisits(bookshelf),
 		EditorType: editorType(bookshelf),
-		Entity: entity(bookshelf),
+		Entity: entity.entity(bookshelf),
 		Gender: gender(bookshelf),
 		Identifier: identifier(bookshelf),
 		IdentifierSet: identifierSet(bookshelf),

--- a/src/index.js
+++ b/src/index.js
@@ -122,6 +122,7 @@ export default function init(config) {
 		Language: language(bookshelf),
 		LanguageSet: languageSet(bookshelf),
 		MapRevisionsToAlias: revision.mapRevisionsToAlias(bookshelf),
+		MostRecentEntityRevisions: entity.mostRecentEntityRevisions(bookshelf),
 		Note: note(bookshelf),
 		Publication: publication(bookshelf),
 		PublicationData,

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+import * as revision from './models/revision';
 import * as util from './util'; // eslint-disable-line import/no-namespace
 
 import Bookshelf from 'bookshelf';
@@ -65,7 +66,6 @@ import relationshipSet from './models/relationshipSet';
 import relationshipType from './models/relationshipType';
 import releaseEvent from './models/releaseEvent';
 import releaseEventSet from './models/releaseEventSet';
-import revision from './models/revision';
 import titleType from './models/titleType';
 import titleUnlock from './models/titleUnlock';
 import work from './models/entities/work';
@@ -138,7 +138,7 @@ export default function init(config) {
 		RelationshipType: relationshipType(bookshelf),
 		ReleaseEvent: releaseEvent(bookshelf),
 		ReleaseEventSet: releaseEventSet(bookshelf),
-		Revision: revision(bookshelf),
+		Revision: revision.revision(bookshelf),
 		TitleType: titleType(bookshelf),
 		TitleUnlock: titleUnlock(bookshelf),
 		Work: work(bookshelf),

--- a/src/models/entity.js
+++ b/src/models/entity.js
@@ -19,7 +19,7 @@
 import {camelToSnake, snakeToCamel} from '../util';
 
 
-export default function entity(bookshelf) {
+export function entity(bookshelf) {
 	const Entity = bookshelf.Model.extend({
 		format: camelToSnake,
 		idAttribute: 'bbid',

--- a/src/models/entity.js
+++ b/src/models/entity.js
@@ -18,6 +18,11 @@
 
 import {camelToSnake, snakeToCamel} from '../util';
 
+import Immutable from 'immutable';
+import Promise from 'bluebird';
+import _ from 'lodash';
+import {mapRevisionsToAlias} from './revision';
+
 
 export function entity(bookshelf) {
 	const Entity = bookshelf.Model.extend({
@@ -31,4 +36,75 @@ export function entity(bookshelf) {
 	});
 
 	return bookshelf.model('Entity', Entity);
+}
+
+/**
+ * Produce a mapping of revisionIds and their default alias names.
+ * @param {object} bookshelf - The Bookshelf object.
+ * @returns {function} The returned function which inputs entityType and limit
+ * 					   signifying the number of recent entities to be retrieved.
+ */
+export function mostRecentEntityRevisions(bookshelf) {
+	return (entityType, limit) => {
+		const rawSql = `
+			SELECT editor.name as editor_name,
+				   alias.name as alias_name,
+				   revision.id as revision_id,
+				   revision.created_at as created_at,
+				   revision_parent.parent_id as parent_id
+			  FROM ${entityType} as en
+			  JOIN revision ON revision.id = en.revision_id
+			  JOIN editor ON editor.id = revision.author_id
+		 LEFT JOIN alias on alias.id = default_alias_id
+		 LEFT JOIN revision_parent on revision_parent.child_id = revision.id
+		  ORDER BY revision.created_at DESC
+			 LIMIT ${limit};
+		`;
+
+		// Query the database to get the revisions
+		const rowsPromise = bookshelf.knex.raw(rawSql).then(val =>
+			val.rows.map((rawQueryResult) => {
+				// Convert query keys to camelCase
+				const queriedResult = _.mapKeys(
+					rawQueryResult,
+					(value, key) => _.camelCase(key)
+				);
+
+				// Add entity type to the queried result
+				queriedResult.type = entityType;
+				// Add action to the queried result
+				if (queriedResult.parentId === null) {
+					queriedResult.action = 'CREATE';
+				}
+				else if (queriedResult.aliasName === null) {
+					queriedResult.action = 'DELETE';
+				}
+				else {
+					queriedResult.action = 'EDIT';
+				}
+				return queriedResult;
+			}));
+
+		// Query the database to get the names of the parentIds of the revisions
+		const parentNamesPromise = rowsPromise.then((rows) =>
+			mapRevisionsToAlias(bookshelf)(
+				entityType,
+				rows.map(row => row.parentId)
+			));
+
+		return Promise.join(
+			rowsPromise,
+			parentNamesPromise,
+			(rows, parentNames) =>
+				// Add the alias name of the parentId if the action is DELETE
+				Immutable.fromJS(rows.map(row => {
+					if (row.action === 'DELETE') {
+						row.aliasName = parentNames.get(
+							row.parentId.toString()
+						);
+					}
+					return row;
+				}))
+		);
+	};
 }

--- a/src/models/revision.js
+++ b/src/models/revision.js
@@ -19,7 +19,7 @@
 import {camelToSnake, snakeToCamel} from '../util';
 
 
-export default function revision(bookshelf) {
+export function revision(bookshelf) {
 	const Revision = bookshelf.Model.extend({
 		author() {
 			return this.belongsTo('Editor', 'author_id');


### PR DESCRIPTION
This PR aims to add queries to extract the most recent entity type revisions, where entity type can be one of the existing {creator, publisher, publication, edition, work}. The number of revisions are limited by the `limit` parameter.