### PR TITLE
chore(greenkeeper): pin eslint-plugin-flowtype to 2.50.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.0.0",
     "eslint-plugin-babel": "^5.0.0",
-    "eslint-plugin-flowtype": "^2.39.1",
+    "eslint-plugin-flowtype": "2.50.0",
     "eslint-plugin-import": "^2.8.0",
     "faker": "^4.1.0",
     "flow-bin": "^0.77.0",


### PR DESCRIPTION
eslint-plugin-flowtype 2.50.1 seemed not to pass build, but 2.50.0 does.