### PR TITLE
Create edition group automatically

### DIFF
--- a/src/models/entities/edition.js
+++ b/src/models/entities/edition.js
@@ -16,6 +16,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+import _ from 'lodash';
 import {createEditionGroupForNewEdition} from '../../util';
 
 
@@ -38,6 +39,11 @@ export default function edition(bookshelf) {
 			this.on('updating', (model, attrs, options) => {
 				// Always update the master revision.
 				options.query.where({master: true});
+				if (_.has(model, 'changed.editionGroupBbid') &&
+					!model.get('editionGroupBbid')
+				) {
+					throw new Error('EditionGroupBbid required in Edition update');
+				}
 			});
 
 			this.on('creating', async (model, attrs, options) => {

--- a/src/util.js
+++ b/src/util.js
@@ -222,3 +222,28 @@ export function parseDate(date) {
 
 	return [null, null, null];
 }
+
+/**
+ * Create a new Edition Group for an Edition.
+ * The Edition Group will be part of the same revision, and will have the same alias set id for that revision
+ * Subsequent changes to the alias set for either entity will only impact that entity's new revision.
+ * @param {object} orm - The Bookshelf ORM
+ * @param {object} transacting - The Bookshelf/Knex SQL transaction in progress
+ * @param {number|string} aliasSetId - The id of the new edition's alias set
+ * @param {number|string} revisionId - The id of the new edition's revision
+ * @returns {string} BBID of the newly created Edition Group
+ */
+export async function createEditionGroupForNewEdition(orm, transacting, aliasSetId, revisionId) {
+	const Entity = orm.model('Entity');
+	const EditionGroup = orm.model('EditionGroup');
+	const newEditionGroupEntity = await new Entity({type: 'EditionGroup'})
+		.save(null, {method: 'insert', transacting});
+	const bbid = newEditionGroupEntity.get('bbid');
+	await new EditionGroup({
+		aliasSetId,
+		bbid,
+		revisionId
+	})
+		.save(null, {method: 'insert', transacting});
+	return bbid;
+}

--- a/test/testEdition.js
+++ b/test/testEdition.js
@@ -153,6 +153,48 @@ describe('Edition model', () => {
 		]);
 	});
 
+	it('should automatically create an Edition Group if none has been passed', async () => {
+		const revisionAttribs = {
+			authorId: 1,
+			id: 1
+		};
+		const editionAttribs = {
+			aliasSetId: 1,
+			annotationId: 1,
+			bbid: aBBID,
+			disambiguationId: 1,
+			identifierSetId: 1,
+			relationshipSetId: 1,
+			revisionId: 1
+		};
+
+		await new Revision(revisionAttribs)
+			.save(null, {method: 'insert'});
+
+		await new Annotation({
+			content: 'Test Annotation',
+			id: 1,
+			lastRevisionId: 1
+		})
+			.save(null, {method: 'insert'});
+
+		const edition = await new Edition(editionAttribs)
+			.save(null, {method: 'insert'});
+		await edition.refresh({
+			withRelated: [
+				'relationshipSet', 'aliasSet', 'identifierSet',
+				'annotation', 'disambiguation', 'authorCredit',
+				'editionGroup'
+			]
+		});
+		const editionJSON = edition.toJSON();
+
+		expect(editionJSON.editionGroupBbid).to.be.a('string');
+		expect(editionJSON.editionGroup.aliasSetId).to.equal(1);
+		expect(editionJSON.editionGroup.revisionId).to.equal(1);
+		expect(editionJSON.editionGroup.dataId).to.not.be.null;
+	});
+
 	it('should return the master revision when multiple revisions exist',
 		() => {
 			/*


### PR DESCRIPTION
Upon creation for Editions that do not have an editionGroupBbid set.

If updating an existing Edition, unsetting editionGroupBbid will throw an error (transactions will roll back)

Also added accompanying test for both cases