### PR TITLE
feat(bc-dates): formatDate returns full ISO 8601-2004 date

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -161,7 +161,7 @@ export function diffRevisions(base, other, includes) {
 	);
 }
 
-const YEAR_STR_LENGTH = 4;
+const YEAR_STR_LENGTH = 6;
 const MONTH_STR_LENGTH = 2;
 const DAY_STR_LENGTH = 2;
 
@@ -177,14 +177,9 @@ export function formatDate(year, month, day) {
 	if (!year || isNaN(parseInt(year, 10))) {
 		return null;
 	}
-	let yearString;
 	const isCommonEraDate = Math.sign(year) === 1;
-	if (isCommonEraDate) {
-		yearString = _.padStart(year.toString(), YEAR_STR_LENGTH, '0');
-	}
-	else {
-		yearString = `-${_.padStart(Math.abs(year).toString(), YEAR_STR_LENGTH, '0')}`;
-	}
+	// eslint-disable-next-line max-len
+	const yearString = `${isCommonEraDate ? '+' : '-'}${_.padStart(Math.abs(year).toString(), YEAR_STR_LENGTH, '0')}`;
 
 	if (!month || isNaN(parseInt(month, 10))) {
 		return `${yearString}`;

--- a/test/util.js
+++ b/test/util.js
@@ -112,26 +112,26 @@ describe('Utils', () => {
 
 		it('should return the date as ISO 8601 for a full date object', () => {
 			const parsedDate = formatDate(1925, 4, '28');
-			expect(parsedDate).to.equal('1925-04-28');
+			expect(parsedDate).to.equal('+001925-04-28');
 		});
 
 		it('should return the date as ISO 8601 for a date object with missing month', () => {
-			const parsedDate = formatDate('1925', '4');
-			expect(parsedDate).to.equal('1925-04');
+			const parsedDate = formatDate('+001925', '4');
+			expect(parsedDate).to.equal('+001925-04');
 		});
 
 		it('should return the date as ISO 8601 for a date object with missing month and day', () => {
 			const parsedDate = formatDate(1925);
-			expect(parsedDate).to.equal('1925');
+			expect(parsedDate).to.equal('+001925');
 		});
 
 		it('should allow negative years for full date and with missing month and/or day', () => {
 			let parsedDate = formatDate(-1925);
-			expect(parsedDate).to.equal('-1925');
-			parsedDate = formatDate('-1925', 4);
-			expect(parsedDate).to.equal('-1925-04');
+			expect(parsedDate).to.equal('-001925');
+			parsedDate = formatDate('-001925', 4);
+			expect(parsedDate).to.equal('-001925-04');
 			parsedDate = formatDate(-1925, '4', '04');
-			expect(parsedDate).to.equal('-1925-04-04');
+			expect(parsedDate).to.equal('-001925-04-04');
 		});
 	});
 });


### PR DESCRIPTION
No ambiguity for negative/positive years
eg: +002019-01-01, -000100