### PR TITLE
chore: Update Bookshelf and Knex ORM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -510,8 +510,7 @@
                 "ansi-regex": {
                   "version": "2.1.1",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "dev": true
                 },
                 "aproba": {
                   "version": "1.2.0",
@@ -532,14 +531,12 @@
                 "balanced-match": {
                   "version": "1.0.0",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "dev": true
                 },
                 "brace-expansion": {
                   "version": "1.1.11",
                   "bundled": true,
                   "dev": true,
-                  "optional": true,
                   "requires": {
                     "balanced-match": "^1.0.0",
                     "concat-map": "0.0.1"
@@ -554,20 +551,17 @@
                 "code-point-at": {
                   "version": "1.1.0",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "dev": true
                 },
                 "concat-map": {
                   "version": "0.0.1",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "dev": true
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "dev": true
                 },
                 "core-util-is": {
                   "version": "1.0.2",
@@ -684,8 +678,7 @@
                 "inherits": {
                   "version": "2.0.3",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "dev": true
                 },
                 "ini": {
                   "version": "1.3.5",
@@ -697,7 +690,6 @@
                   "version": "1.0.0",
                   "bundled": true,
                   "dev": true,
-                  "optional": true,
                   "requires": {
                     "number-is-nan": "^1.0.0"
                   }
@@ -712,7 +704,6 @@
                   "version": "3.0.4",
                   "bundled": true,
                   "dev": true,
-                  "optional": true,
                   "requires": {
                     "brace-expansion": "^1.1.7"
                   }
@@ -720,14 +711,12 @@
                 "minimist": {
                   "version": "0.0.8",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "dev": true
                 },
                 "minipass": {
                   "version": "2.3.5",
                   "bundled": true,
                   "dev": true,
-                  "optional": true,
                   "requires": {
                     "safe-buffer": "^5.1.2",
                     "yallist": "^3.0.0"
@@ -746,7 +735,6 @@
                   "version": "0.5.1",
                   "bundled": true,
                   "dev": true,
-                  "optional": true,
                   "requires": {
                     "minimist": "0.0.8"
                   }
@@ -827,8 +815,7 @@
                 "number-is-nan": {
                   "version": "1.0.1",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "dev": true
                 },
                 "object-assign": {
                   "version": "4.1.1",
@@ -840,7 +827,6 @@
                   "version": "1.4.0",
                   "bundled": true,
                   "dev": true,
-                  "optional": true,
                   "requires": {
                     "wrappy": "1"
                   }
@@ -926,8 +912,7 @@
                 "safe-buffer": {
                   "version": "5.1.2",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "dev": true
                 },
                 "safer-buffer": {
                   "version": "2.1.2",
@@ -963,7 +948,6 @@
                   "version": "1.0.2",
                   "bundled": true,
                   "dev": true,
-                  "optional": true,
                   "requires": {
                     "code-point-at": "^1.0.0",
                     "is-fullwidth-code-point": "^1.0.0",
@@ -983,7 +967,6 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "dev": true,
-                  "optional": true,
                   "requires": {
                     "ansi-regex": "^2.0.0"
                   }
@@ -1027,14 +1010,12 @@
                 "wrappy": {
                   "version": "1.0.2",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "dev": true
                 },
                 "yallist": {
                   "version": "3.0.3",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "dev": true
                 }
               }
             }
@@ -1074,15 +1055,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -2018,17 +1997,41 @@
       "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "bookshelf": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/bookshelf/-/bookshelf-0.13.3.tgz",
-      "integrity": "sha512-QELg3tur8KWFmsYcMOvn0APl9tfov0bXqXAqLmDUcCf5oF0Aw/4w1iFR2ttuDhrdw7GjVyZWOnx/XiMZSx4vSQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bookshelf/-/bookshelf-1.0.1.tgz",
+      "integrity": "sha512-x3Pk60r4EzQ+ZJElfT20cWUFb9HA/7B4IBAQjlMpokuteDxwiAnAUi4ZJtKwcDHKvII4OfebzbzkQBLv5E/djg==",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "bluebird": "^3.4.3",
-        "chalk": "^2.3.0",
+        "bluebird": "^3.5.5",
         "create-error": "~0.3.1",
-        "inflection": "^1.5.1",
-        "inherits": "~2.0.1",
-        "lodash": "^4.13.1"
+        "inflection": "^1.12.0",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+          "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg=="
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
+      }
+    },
+    "bookshelf-virtuals-plugin": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/bookshelf-virtuals-plugin/-/bookshelf-virtuals-plugin-0.1.1.tgz",
+      "integrity": "sha512-MFFjtzLoyWaGD7eMT2UZ8H00CHNk7M5WuSTxi+82gLJqbq0TyQdSQsKS5/NHfQjqd3wZKEV+yEbzpck2oBGe2A==",
+      "requires": {
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "boxen": {
@@ -2720,6 +2723,9 @@
       "requires": {
         "@types/glob": "^7.1.1",
         "globby": "^6.1.0",
+        "is-path-cwd": "^2.0.0",
+        "is-path-in-cwd": "^2.0.0",
+        "p-map": "^2.0.0",
         "pify": "^4.0.1",
         "rimraf": "^2.6.3"
       },
@@ -2738,23 +2744,11 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "is-path-cwd": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-          "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
-        },
-        "is-path-in-cwd": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-          "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-          "requires": {
-            "is-path-inside": "^1.0.0"
-          }
-        },
         "p-map": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-          "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+          "dev": true
         },
         "pify": {
           "version": "4.0.1",
@@ -3852,8 +3846,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3871,13 +3864,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3890,18 +3881,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4004,8 +3992,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4015,7 +4002,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4028,20 +4014,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4058,7 +4041,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4137,8 +4119,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4148,7 +4129,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4224,8 +4204,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4255,7 +4234,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4273,7 +4251,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4312,13 +4289,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -4407,15 +4382,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -5282,6 +5255,32 @@
       "dev": true,
       "requires": {
         "symbol-observable": "^1.1.0"
+      }
+    },
+    "is-path-cwd": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+      "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "^2.1.0"
+      },
+      "dependencies": {
+        "is-path-inside": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
+          "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
+          "dev": true,
+          "requires": {
+            "path-is-inside": "^1.0.2"
+          }
+        }
       }
     },
     "is-path-inside": {
@@ -7549,8 +7548,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1867,6 +1867,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -2435,10 +2436,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
     },
+    "colorette": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.1.0.tgz",
+      "integrity": "sha512-6S062WDQUXi6hOfkO/sBPVwE5ASXY4G2+b4atvhJfSsuUUhIaUKlkjLe9692Ipyt5/a+IPF5aVTu3V5gvXq5cg=="
+    },
     "commander": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
-      "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew=="
+      "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew==",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -2489,7 +2496,8 @@
     "core-js": {
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3653,20 +3661,30 @@
       }
     },
     "findup-sync": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
-      "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
+      "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
       "requires": {
         "detect-file": "^1.0.0",
-        "is-glob": "^3.1.0",
+        "is-glob": "^4.0.0",
         "micromatch": "^3.0.4",
         "resolve-dir": "^1.0.1"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        }
       }
     },
     "fined": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
-      "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
+      "integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
       "requires": {
         "expand-tilde": "^2.0.2",
         "is-plain-object": "^2.0.3",
@@ -3676,9 +3694,9 @@
       }
     },
     "flagged-respawn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.0.tgz",
-      "integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
+      "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q=="
     },
     "flat": {
       "version": "4.1.0",
@@ -4343,6 +4361,11 @@
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
+    "getopts": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.2.5.tgz",
+      "integrity": "sha512-9jb7AW5p3in+IiJWhQiZmmwkpLaR/ccTWdWQCtZM66HJcHHLegowh4q4tSD7gouUyeNvFWRavfK9GXosQHDpFA=="
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -4602,9 +4625,9 @@
       }
     },
     "homedir-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
       "requires": {
         "parse-passwd": "^1.0.0"
       }
@@ -5027,9 +5050,9 @@
       }
     },
     "interpret": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
     },
     "invariant": {
       "version": "2.2.4",
@@ -5828,37 +5851,64 @@
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
     },
     "knex": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-0.15.2.tgz",
-      "integrity": "sha1-YFm4dIlgX0zIdZmm0qnSZXCek0A=",
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-0.19.5.tgz",
+      "integrity": "sha512-Hy258avCVircQq+oj3WBqPzl8jDIte438Qlq+8pt1i/TyLYVA4zPh2uKc7Bx0t+qOpa6D42HJ2jjtl2vagzilw==",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "bluebird": "^3.5.1",
-        "chalk": "2.3.2",
-        "commander": "^2.16.0",
-        "debug": "3.1.0",
-        "inherits": "~2.0.3",
-        "interpret": "^1.1.0",
-        "liftoff": "2.5.0",
-        "lodash": "^4.17.10",
-        "minimist": "1.2.0",
+        "bluebird": "^3.7.0",
+        "colorette": "1.1.0",
+        "commander": "^3.0.2",
+        "debug": "4.1.1",
+        "getopts": "2.2.5",
+        "inherits": "~2.0.4",
+        "interpret": "^1.2.0",
+        "liftoff": "3.1.0",
+        "lodash": "^4.17.15",
         "mkdirp": "^0.5.1",
-        "pg-connection-string": "2.0.0",
-        "tarn": "^1.1.4",
-        "tildify": "1.2.0",
-        "uuid": "^3.3.2",
-        "v8flags": "^3.1.1"
+        "pg-connection-string": "2.1.0",
+        "tarn": "^2.0.0",
+        "tildify": "2.0.0",
+        "uuid": "^3.3.3",
+        "v8flags": "^3.1.3"
       },
       "dependencies": {
-        "chalk": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+        "bluebird": {
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+          "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg=="
+        },
+        "commander": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+          "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ms": "^2.1.1"
           }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "uuid": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+          "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
         }
       }
     },
@@ -5890,12 +5940,12 @@
       }
     },
     "liftoff": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
-      "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-3.1.0.tgz",
+      "integrity": "sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==",
       "requires": {
         "extend": "^3.0.0",
-        "findup-sync": "^2.0.0",
+        "findup-sync": "^3.0.0",
         "fined": "^1.0.1",
         "flagged-respawn": "^1.0.0",
         "is-plain-object": "^2.0.4",
@@ -7399,7 +7449,8 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
     },
     "os-locale": {
       "version": "2.1.0",
@@ -7696,9 +7747,9 @@
       }
     },
     "pg-connection-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.0.0.tgz",
-      "integrity": "sha1-Pu/lmX4G2Ugh5NUC5CtqHHP434I="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.1.0.tgz",
+      "integrity": "sha512-bhlV7Eq09JrRIvo1eKngpwuqKtJnNhZdpdOlvrPrA4dxqXPjxSrbNrfnIDmTpwMyRszrcV4kU5ZA4mMsQUrjdg=="
     },
     "pg-int8": {
       "version": "1.0.1",
@@ -7996,7 +8047,8 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.10.1",
@@ -8720,9 +8772,9 @@
       }
     },
     "tarn": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/tarn/-/tarn-1.1.4.tgz",
-      "integrity": "sha512-j4samMCQCP5+6Il9/cxCqBd3x4vvlLeVdoyGex0KixPKl4F8LpNbDSC6NDhjianZgUngElRr9UI1ryZqJDhwGg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tarn/-/tarn-2.0.0.tgz",
+      "integrity": "sha512-7rNMCZd3s9bhQh47ksAQd92ADFcJUjjbyOvyFjNLwTPpGieFHMC84S+LOzw0fx1uh6hnDz/19r8CPMnIjJlMMA=="
     },
     "term-size": {
       "version": "1.2.0",
@@ -8879,12 +8931,9 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "tildify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
-      "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
-      "requires": {
-        "os-homedir": "^1.0.0"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tildify/-/tildify-2.0.0.tgz",
+      "integrity": "sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw=="
     },
     "timed-out": {
       "version": "4.0.1",
@@ -9194,7 +9243,8 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.0.3",
@@ -9203,9 +9253,9 @@
       "dev": true
     },
     "v8flags": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.1.tgz",
-      "integrity": "sha512-iw/1ViSEaff8NJ3HLyEjawk/8hjJib3E7pvG4pddVXfUg1983s3VGsiClDjhK64MQVDGqc1Q8r18S4VKQZS9EQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
+      "integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
       "requires": {
         "homedir-polyfill": "^1.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "bookshelf-virtuals-plugin": "^0.1.1",
     "deep-diff": "^1.0.0",
     "immutable": "^3.8.2",
-    "knex": "^0.15.0",
+    "knex": "^0.19.5",
     "lodash": "^4.17.11",
     "moment": "^2.22.2",
     "nodemon": "^1.18.3",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
   "homepage": "https://github.com/bookbrainz/bookbrainz-data-js",
   "dependencies": {
     "bluebird": "^3.5.1",
-    "bookshelf": "^0.13.3",
+    "bookshelf": "^1.0.1",
+    "bookshelf-virtuals-plugin": "^0.1.1",
     "deep-diff": "^1.0.0",
     "immutable": "^3.8.2",
     "knex": "^0.15.0",

--- a/src/func/author-credit.js
+++ b/src/func/author-credit.js
@@ -112,11 +112,11 @@ export function updateAuthorCredit(
 	/* eslint-enable consistent-return */
 
 	const oldCreditNames: Array<AuthorCreditNameT> =
-		oldCredit ? oldCredit.related('names').toJSON() : [];
-
-	if (_.isEqualWith(oldCreditNames, newCreditNames, comparisonFunc)) {
+		oldCredit ? _.orderBy(oldCredit.related('names').toJSON(), 'position') : [];
+	const sortedNewCreditNames = _.orderBy(newCreditNames, 'position');
+	if (_.isEqualWith(oldCreditNames, sortedNewCreditNames, comparisonFunc)) {
 		return Promise.resolve(oldCredit || null);
 	}
 
-	return fetchOrCreateCredit(orm, transacting, newCreditNames);
+	return fetchOrCreateCredit(orm, transacting, sortedNewCreditNames);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -89,9 +89,7 @@ import workType from './models/workType';
  */
 export default function init(config) {
 	const bookshelf = Bookshelf(knex(config));
-	bookshelf.plugin('registry');
-	bookshelf.plugin('visibility');
-	bookshelf.plugin('virtuals');
+	bookshelf.plugin('bookshelf-virtuals-plugin');
 
 	// Initialize these here to set up dependencies
 	const AuthorData = authorData(bookshelf);

--- a/test/func/alias.js
+++ b/test/func/alias.js
@@ -110,7 +110,7 @@ describe('updateAliasSet', () => {
 			return set.refresh({transacting: trx, withRelated: 'aliases'});
 		});
 
-		const firstSetAliases = firstSet.related('aliases').toJSON();
+		const firstSetAliases = _.sortBy(firstSet.related('aliases').toJSON(), 'id');
 
 		const thirdAliasData = getAliasData();
 		thirdAliasData.id = firstSetAliases[1].id;
@@ -130,7 +130,7 @@ describe('updateAliasSet', () => {
 			return set.refresh({transacting: trx, withRelated: 'aliases'});
 		});
 
-		const aliases = result.related('aliases').toJSON();
+		const aliases = _.sortBy(result.related('aliases').toJSON(), 'id');
 
 		expect(result.get('id')).to.not.equal(firstSet.get('id'));
 		expect(result.get('defaultAliasId')).to.equal(aliases[0].id);
@@ -155,7 +155,7 @@ describe('updateAliasSet', () => {
 			return set.refresh({transacting: trx, withRelated: 'aliases'});
 		});
 
-		const firstSetAliases = firstSet.related('aliases').toJSON();
+		const firstSetAliases = _.orderBy(firstSet.related('aliases').toJSON(), 'id');
 
 		const result = await bookshelf.transaction(async (trx) => {
 			const [defaultAlias, ...others] = firstSetAliases;
@@ -170,7 +170,7 @@ describe('updateAliasSet', () => {
 			return set.refresh({transacting: trx, withRelated: 'aliases'});
 		});
 
-		const aliases = result.related('aliases').toJSON();
+		const aliases = _.orderBy(result.related('aliases').toJSON(), 'id');
 
 		expect(result.get('id')).to.equal(firstSet.get('id'));
 		expect(result.get('defaultAliasId')).to.equal(aliases[0].id);
@@ -196,7 +196,7 @@ describe('updateAliasSet', () => {
 			return set.refresh({transacting: trx, withRelated: 'aliases'});
 		});
 
-		const firstSetAliases = firstSet.related('aliases').toJSON();
+		const firstSetAliases = _.orderBy(firstSet.related('aliases').toJSON(), 'id');
 
 		const others = _.initial(firstSetAliases);
 		const defaultAlias = _.last(firstSetAliases);
@@ -213,7 +213,7 @@ describe('updateAliasSet', () => {
 			return set.refresh({transacting: trx, withRelated: 'aliases'});
 		});
 
-		const aliases = result.related('aliases').toJSON();
+		const aliases = _.orderBy(result.related('aliases').toJSON(), 'id');
 
 		expect(result.get('id')).to.not.equal(firstSet.get('id'));
 		expect(result.get('defaultAliasId')).to.equal(aliases[1].id);

--- a/test/func/author-credit.js
+++ b/test/func/author-credit.js
@@ -145,15 +145,16 @@ describe('updateCreateCredit', () => {
 			(trx) => updateAuthorCredit(bookbrainzData, trx, firstCredit, data)
 		);
 
-		const firstCreditJSON = firstCredit.toJSON();
-		const secondCreditJSON = secondCredit.toJSON();
 
-		expect(firstCreditJSON.id).to.not.equal(secondCreditJSON.id);
-		expect(_.get(secondCreditJSON, 'names[0].authorBBID')).to.equal(cBBID);
-		expect(_.get(firstCreditJSON, 'names[0].authorCreditID')).to.not
-			.equal(_.get(secondCreditJSON, 'names[0].authorCreditID'));
-		expect(_.get(firstCreditJSON, 'names[1].authorCreditID')).to.not
-			.equal(_.get(secondCreditJSON, 'names[1].authorCreditID'));
+		const firstCreditNames = _.orderBy(firstCredit.related('names').toJSON(), 'position');
+		const secondCreditNames = _.orderBy(secondCredit.related('names').toJSON(), 'position');
+
+		expect(firstCredit.get('id')).to.not.equal(secondCredit.get('id'));
+		expect(_.get(secondCreditNames, '[0].authorBBID')).to.equal(cBBID);
+		expect(_.get(firstCreditNames, '[0].authorCreditID')).to.not
+			.equal(_.get(secondCreditNames, '[0].authorCreditID'));
+		expect(_.get(firstCreditNames, '[1].authorCreditID')).to.not
+			.equal(_.get(secondCreditNames, '[1].authorCreditID'));
 	});
 
 	/* eslint-disable-next-line max-len */
@@ -180,14 +181,14 @@ describe('updateCreateCredit', () => {
 				updateAuthorCredit(bookbrainzData, trx, secondCredit, data)
 		);
 
-		const firstCreditJSON = firstCredit.toJSON();
-		const thirdCreditJSON = thirdCredit.toJSON();
+		const firstCreditNames = _.orderBy(firstCredit.related('names').toJSON(), 'position');
+		const thirdCreditNames = _.orderBy(thirdCredit.related('names').toJSON(), 'position');
 
-		expect(firstCreditJSON.id).to.equal(thirdCreditJSON.id);
-		expect(_.get(thirdCreditJSON, 'names[0].authorBBID')).to.equal(aBBID);
-		expect(_.get(firstCreditJSON, 'names[0].authorCreditID')).to
-			.equal(_.get(thirdCreditJSON, 'names[0].authorCreditID'));
-		expect(_.get(firstCreditJSON, 'names[1].authorCreditID')).to
-			.equal(_.get(thirdCreditJSON, 'names[1].authorCreditID'));
+		expect(firstCredit.get('id')).to.equal(thirdCredit.get('id'));
+		expect(_.get(thirdCreditNames, '[0].authorBBID')).to.equal(aBBID);
+		expect(_.get(firstCreditNames, '[0].authorCreditID')).to
+			.equal(_.get(thirdCreditNames, '[0].authorCreditID'));
+		expect(_.get(firstCreditNames, '[1].authorCreditID')).to
+			.equal(_.get(thirdCreditNames, '[1].authorCreditID'));
 	});
 });

--- a/test/func/identifier.js
+++ b/test/func/identifier.js
@@ -104,7 +104,7 @@ describe('updateIdentifierSet', () => {
 			return set.refresh({transacting: trx, withRelated: 'identifiers'});
 		});
 
-		const firstSetIdentifiers = firstSet.related('identifiers').toJSON();
+		const firstSetIdentifiers = _.orderBy(firstSet.related('identifiers').toJSON(), 'id');
 
 		const thirdIdentifierData = getIdentifierData();
 		thirdIdentifierData.id = firstSetIdentifiers[1].id;
@@ -122,7 +122,7 @@ describe('updateIdentifierSet', () => {
 			return set.refresh({transacting: trx, withRelated: 'identifiers'});
 		});
 
-		const identifiers = result.related('identifiers').toJSON();
+		const identifiers = _.orderBy(result.related('identifiers').toJSON(), 'id');
 
 		expect(result.get('id')).to.not.equal(firstSet.get('id'));
 		expect(identifiers).to.have.lengthOf(2);
@@ -145,7 +145,7 @@ describe('updateIdentifierSet', () => {
 			return set.refresh({transacting: trx, withRelated: 'identifiers'});
 		});
 
-		const firstSetIdentifiers = firstSet.related('identifiers').toJSON();
+		const firstSetIdentifiers = _.orderBy(firstSet.related('identifiers').toJSON(), 'id');
 
 		const result = await bookshelf.transaction(async (trx) => {
 			const set = await updateIdentifierSet(
@@ -158,7 +158,7 @@ describe('updateIdentifierSet', () => {
 			return set.refresh({transacting: trx, withRelated: 'identifiers'});
 		});
 
-		const identifiers = result.related('identifiers').toJSON();
+		const identifiers = _.orderBy(result.related('identifiers').toJSON(), 'id');
 
 		expect(result.get('id')).to.equal(firstSet.get('id'));
 		expect(identifiers).to.have.lengthOf(2);

--- a/test/func/relationship.js
+++ b/test/func/relationship.js
@@ -243,7 +243,7 @@ describe('updateRelationshipSet', () => {
 		});
 
 		const firstSet = firstResult[aBBID];
-		const firstSetRelationships = firstSet.related('relationships').toJSON()
+		const firstSetRelationships = _.orderBy(firstSet.related('relationships').toJSON(), 'id')
 			.map((relationship) =>
 				_.pick(relationship, ['typeId', 'sourceBbid', 'targetBbid']));
 
@@ -263,15 +263,18 @@ describe('updateRelationshipSet', () => {
 				}, {})
 			);
 		});
+		const aBBIDRelationships = _.orderBy(result[aBBID].related('relationships').toJSON(), 'id');
+		const cBBIDRelationships = result[cBBID];
+		const dBBIDRelationships = _.orderBy(result[dBBID].related('relationships').toJSON(), 'id');
 
 		expect(result)
 			.to.be.an('object').that.has.all.keys(aBBID, cBBID, dBBID);
-		expect(result[aBBID].related('relationships').toJSON()[0])
+		expect(aBBIDRelationships[0])
 			.to.be.an('object').to.include(firstRelationshipData);
-		expect(result[aBBID].related('relationships').toJSON()[1])
+		expect(aBBIDRelationships[1])
 			.to.be.an('object').to.include(thirdRelationshipData);
-		expect(result[cBBID]).to.be.null;
-		expect(result[dBBID].related('relationships').toJSON()[0])
+		expect(cBBIDRelationships).to.be.null;
+		expect(dBBIDRelationships[0])
 			.to.be.an('object').to.include(thirdRelationshipData);
 	});
 

--- a/test/func/set.js
+++ b/test/func/set.js
@@ -16,6 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+import _ from 'lodash';
 import bookbrainzData from '../bookshelf';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -231,7 +232,7 @@ describe('createNewSetWithItems', () => {
 			}
 		);
 
-		const firstSetItems = firstSet.related('aliases').toJSON();
+		const firstSetItems = _.orderBy(firstSet.related('aliases').toJSON(), 'id');
 
 		const secondAliasData = getAliasData();
 		const resultSet = await bookshelf.transaction(
@@ -249,7 +250,7 @@ describe('createNewSetWithItems', () => {
 			}
 		);
 
-		const items = resultSet.related('aliases').toJSON();
+		const items = _.orderBy(resultSet.related('aliases').toJSON(), 'id');
 
 		expect(items).to.have.lengthOf(2);
 		expect(items[0]).to.include({


### PR DESCRIPTION
Update BookshelfJS to version 1.x (from 0.15.x), and resolve high severity vulnerability with Knex (See #199 ).

Following the update, a small change is required in the bookbrainz-site repo (in the [awardUnlock function](https://github.com/bookbrainz/bookbrainz-site/blob/07fd0f62bda21146d466c7fbcc06e20bcd10237c/src/server/helpers/achievement.js#L42-L55)), following some changes with the `fetch()` method:
https://github.com/bookshelf/bookshelf/wiki/Migrating-from-0.15.1-to-1.0.0#default-to-require-true-on-modelfetch-and-collectionfetchone