### PR TITLE
Fix(update-bookshelf): Set 'require' fetch option to false where needed

### DIFF
--- a/src/func/entity-sets.js
+++ b/src/func/entity-sets.js
@@ -82,6 +82,7 @@ export async function updateEntitySets(
 		const oldSetRecord = await derivedSet.model.forge({
 			id: currentEntity[derivedSet.name].id
 		}).fetch({
+			require: false,
 			transacting,
 			withRelated: [derivedSet.propName]
 		});

--- a/src/func/relationship.js
+++ b/src/func/relationship.js
@@ -64,7 +64,8 @@ async function getMasterRelationshipSetForEntity(
 	const type: EntityTypeString = entityHeader.get('type');
 
 	// Fetch master revision of entity
-	const entity = await typeModelMap[type].forge({bbid}).fetch({transacting});
+	const entity = await typeModelMap[type].forge({bbid})
+		.fetch({require: false, transacting});
 
 	if (!entity) {
 		return null;

--- a/src/models/data/publisherData.js
+++ b/src/models/data/publisherData.js
@@ -53,7 +53,7 @@ export default function publisherData(bookshelf) {
 						'bookbrainz.publisher_set__publisher.publisher_bbid':
 							bbid
 					});
-			}).fetchAll(options);
+			}).fetchAll({require: false, ...options});
 		},
 		format: camelToSnake,
 		idAttribute: 'id',

--- a/src/models/revisions/authorRevision.js
+++ b/src/models/revisions/authorRevision.js
@@ -40,7 +40,7 @@ export default function authorRevision(bookshelf) {
 		idAttribute: 'id',
 		parent() {
 			return this.related('revision').fetch()
-				.then((revision) => revision.related('parents').fetch())
+				.then((revision) => revision.related('parents').fetch({require: false}))
 				.then((parents) => parents.map((parent) => parent.get('id')))
 				.then((parentIds) => {
 					if (parentIds.length === 0) {

--- a/src/models/revisions/editionGroupRevision.js
+++ b/src/models/revisions/editionGroupRevision.js
@@ -40,7 +40,7 @@ export default function editionGroupRevision(bookshelf) {
 		idAttribute: 'id',
 		parent() {
 			return this.related('revision').fetch()
-				.then((revision) => revision.related('parents').fetch())
+				.then((revision) => revision.related('parents').fetch({require: false}))
 				.then((parents) => parents.map((parent) => parent.get('id')))
 				.then((parentIds) => {
 					if (parentIds.length === 0) {

--- a/src/models/revisions/editionRevision.js
+++ b/src/models/revisions/editionRevision.js
@@ -42,7 +42,7 @@ export default function editionRevision(bookshelf) {
 		idAttribute: 'id',
 		parent() {
 			return this.related('revision').fetch()
-				.then((revision) => revision.related('parents').fetch())
+				.then((revision) => revision.related('parents').fetch({require: false}))
 				.then((parents) => parents.map((parent) => parent.get('id')))
 				.then((parentIds) => {
 					if (parentIds.length === 0) {

--- a/src/models/revisions/publisherRevision.js
+++ b/src/models/revisions/publisherRevision.js
@@ -40,7 +40,7 @@ export default function publisherRevision(bookshelf) {
 		idAttribute: 'id',
 		parent() {
 			return this.related('revision').fetch()
-				.then((revision) => revision.related('parents').fetch())
+				.then((revision) => revision.related('parents').fetch({require: false}))
 				.then((parents) => parents.map((parent) => parent.get('id')))
 				.then((parentIds) => {
 					if (parentIds.length === 0) {

--- a/src/models/revisions/workRevision.js
+++ b/src/models/revisions/workRevision.js
@@ -40,7 +40,7 @@ export default function workRevision(bookshelf) {
 		idAttribute: 'id',
 		parent() {
 			return this.related('revision').fetch()
-				.then((revision) => revision.related('parents').fetch())
+				.then((revision) => revision.related('parents').fetch({require: false}))
 				.then((parents) => parents.map((parent) => parent.get('id')))
 				.then((parentIds) => {
 					if (parentIds.length === 0) {

--- a/src/util.js
+++ b/src/util.js
@@ -136,7 +136,7 @@ export function diffRevisions(base, other, includes) {
 		return data;
 	}
 
-	const baseDataPromise = base.related('data').fetch({withRelated: includes});
+	const baseDataPromise = base.related('data').fetch({require: false, withRelated: includes});
 
 	if (!other) {
 		return baseDataPromise.then(
@@ -149,7 +149,7 @@ export function diffRevisions(base, other, includes) {
 	}
 
 	const otherDataPromise =
-		other.related('data').fetch({withRelated: includes});
+		other.related('data').fetch({require: false, withRelated: includes});
 
 	return Promise.join(
 		baseDataPromise,


### PR DESCRIPTION
After v1.x update (PR #200 ), require is the default fetch option and exceptions are thrown in places they shouldn't.