### PR TITLE
fix(ReleaseEvents): Consider null and undefined areas equal

### DIFF
--- a/src/func/releaseEvent.js
+++ b/src/func/releaseEvent.js
@@ -31,7 +31,9 @@ export function updateReleaseEventSet(
 	newSetItems: Array<ReleaseEvent>
 ): Promise<any> {
 	function comparisonFunc(obj, other) {
-		return obj.date === other.date && obj.areaId === other.areaId;
+		return obj.date === other.date &&
+		// Compare areaIds are equal or both null or undefined
+		(obj.areaId === other.areaId || _.isNil(obj.areaId) && _.isNil(other.areaId));
 	}
 
 	const {ReleaseEventSet} = orm;


### PR DESCRIPTION
in updateReleaseEventSet.

The issue appeared in https://github.com/bookbrainz/bookbrainz-site/pull/342 .
If one areaId is null and the other undefined, they are currently considered not equal.

Broaden the scope and consider nil values equal.