### PR TITLE
BB-434 fix: allow year=0 in ISO date parsing

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -175,7 +175,7 @@ const DAY_STR_LENGTH = 2;
  *                   date.
  */
 export function formatDate(year, month, day) {
-	if ((!year || isNaN(parseInt(year, 10))) && year!==0) {
+	if ((!year || isNaN(parseInt(year, 10))) && year !== 0) {
 		return null;
 	}
 	const isCommonEraDate = Math.sign(year) === 1;

--- a/src/util.js
+++ b/src/util.js
@@ -175,7 +175,7 @@ const DAY_STR_LENGTH = 2;
  *                   date.
  */
 export function formatDate(year, month, day) {
-	if ((!year || isNaN(parseInt(year, 10))) && year!=0 ) {
+	if ((!year || isNaN(parseInt(year, 10))) && year!==0) {
 		return null;
 	}
 	const isCommonEraDate = Math.sign(year) === 1;

--- a/src/util.js
+++ b/src/util.js
@@ -178,7 +178,7 @@ export function formatDate(year, month, day) {
 	if ((!year || isNaN(parseInt(year, 10))) && year !== 0) {
 		return null;
 	}
-	const isCommonEraDate = Math.sign(year) === 1;
+	const isCommonEraDate = Math.sign(year) === 1 || Math.sign(year) === 0;
 	// eslint-disable-next-line max-len
 	const yearString = `${isCommonEraDate ? '+' : '-'}${_.padStart(Math.abs(year).toString(), YEAR_STR_LENGTH, '0')}`;
 

--- a/src/util.js
+++ b/src/util.js
@@ -175,7 +175,7 @@ const DAY_STR_LENGTH = 2;
  *                   date.
  */
 export function formatDate(year, month, day) {
-	if ((!year || isNaN(parseInt(year, 10))) && year !== 0 ) {
+	if ((!year || isNaN(parseInt(year, 10))) && year!==0) {
 		return null;
 	}
 	const isCommonEraDate = Math.sign(year) === 1;

--- a/src/util.js
+++ b/src/util.js
@@ -175,7 +175,7 @@ const DAY_STR_LENGTH = 2;
  *                   date.
  */
 export function formatDate(year, month, day) {
-	if (!year || isNaN(parseInt(year, 10))) {
+	if ((!year || isNaN(parseInt(year, 10))) && year!=0 ) {
 		return null;
 	}
 	const isCommonEraDate = Math.sign(year) === 1;

--- a/src/util.js
+++ b/src/util.js
@@ -175,7 +175,7 @@ const DAY_STR_LENGTH = 2;
  *                   date.
  */
 export function formatDate(year, month, day) {
-	if ((!year || isNaN(parseInt(year, 10))) && year!==0) {
+	if ((!year || isNaN(parseInt(year, 10))) && year !== 0 ) {
 		return null;
 	}
 	const isCommonEraDate = Math.sign(year) === 1;

--- a/test/util.js
+++ b/test/util.js
@@ -111,6 +111,11 @@ describe('Utils', () => {
 			expect(result).to.be.false;
 		});
 
+		it('should return the date as ISO 8601 for a date object with year equal to zero', () => {
+			const parsedDate = formatDate(0, 1, 1);
+			expect(parsedDate).to.equal('+000000-01-01');
+		});
+
 		it('should return the date as ISO 8601 for a full date object', () => {
 			const parsedDate = formatDate(1925, 4, '28');
 			expect(parsedDate).to.equal('+001925-04-28');


### PR DESCRIPTION
Condition for year = 0 was not properly handled. Added an and condition