### PR TITLE
fix(parent-revision): return the correct parent revision

### DIFF
--- a/src/models/revisions/authorRevision.js
+++ b/src/models/revisions/authorRevision.js
@@ -47,8 +47,10 @@ export default function authorRevision(bookshelf) {
 						return null;
 					}
 
-					return new AuthorRevision({bbid: this.get('bbid')})
+					return new AuthorRevision()
+						.where('bbid', this.get('bbid'))
 						.query('whereIn', 'id', parentIds)
+						.orderBy('id', 'DESC')
 						.fetch();
 				});
 		},

--- a/src/models/revisions/editionGroupRevision.js
+++ b/src/models/revisions/editionGroupRevision.js
@@ -47,8 +47,10 @@ export default function editionGroupRevision(bookshelf) {
 						return null;
 					}
 
-					return new EditionGroupRevision({bbid: this.get('bbid')})
+					return new EditionGroupRevision()
+						.where('bbid', this.get('bbid'))
 						.query('whereIn', 'id', parentIds)
+						.orderBy('id', 'DESC')
 						.fetch();
 				});
 		},

--- a/src/models/revisions/editionRevision.js
+++ b/src/models/revisions/editionRevision.js
@@ -49,8 +49,10 @@ export default function editionRevision(bookshelf) {
 						return null;
 					}
 
-					return new EditionRevision({bbid: this.get('bbid')})
+					return new EditionRevision()
+						.where('bbid', this.get('bbid'))
 						.query('whereIn', 'id', parentIds)
+						.orderBy('id', 'DESC')
 						.fetch();
 				});
 		},

--- a/src/models/revisions/publisherRevision.js
+++ b/src/models/revisions/publisherRevision.js
@@ -47,8 +47,10 @@ export default function publisherRevision(bookshelf) {
 						return null;
 					}
 
-					return new PublisherRevision({bbid: this.get('bbid')})
+					return new PublisherRevision()
+						.where('bbid', this.get('bbid'))
 						.query('whereIn', 'id', parentIds)
+						.orderBy('id', 'DESC')
 						.fetch();
 				});
 		},

--- a/src/models/revisions/workRevision.js
+++ b/src/models/revisions/workRevision.js
@@ -47,8 +47,10 @@ export default function workRevision(bookshelf) {
 						return null;
 					}
 
-					return new WorkRevision({bbid: this.get('bbid')})
+					return new WorkRevision()
+						.where('bbid', this.get('bbid'))
 						.query('whereIn', 'id', parentIds)
+						.orderBy('id', 'DESC')
 						.fetch();
 				});
 		},


### PR DESCRIPTION
`parent` function inside the `EntityRevision` was giving the wrong parent in some cases.
This PR fixes that. 

