### PR TITLE
fix(diffs): Better sort of identifiers for diff

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -121,7 +121,7 @@ export function diffRevisions(base, other, includes) {
 			data.identifierSet && _.isArray(data.identifierSet.identifiers);
 		if (identifiersPresent) {
 			data.identifierSet.identifiers = _.sortBy(
-				data.identifierSet.identifiers, ['value', 'type.label']
+				data.identifierSet.identifiers, ['type.id', 'value']
 			);
 		}
 


### PR DESCRIPTION
In this example, there were 3 identifiers of the same type, with incremental value (…996, …997, …998).
I modified the second one (…997 -> …9977).
The new sorting accurately recognises only one identifier has been modified, and shows the identifier at that position (2) has changed.

Before:
<img width="1172" alt="Capture d’écran 2020-04-27 à 17 59 51" src="https://user-images.githubusercontent.com/6179856/80393862-5ed7a080-88b1-11ea-9645-ee494c71e8e2.png">


After:
<img width="1175" alt="Capture d’écran 2020-04-27 à 17 54 25" src="https://user-images.githubusercontent.com/6179856/80393876-639c5480-88b1-11ea-9fcf-bba3421c5d41.png">
