### PR TITLE
feat(diffs): Diff authorCredits when present

### DIFF
--- a/src/models/revisions/editionRevision.js
+++ b/src/models/revisions/editionRevision.js
@@ -27,7 +27,7 @@ export default function editionRevision(bookshelf) {
 		diff(other) {
 			return diffRevisions(this, other, [
 				'annotation', 'disambiguation', 'aliasSet.aliases.language',
-				'aliasSet.defaultAlias',
+				'aliasSet.defaultAlias', 'authorCredit.names',
 				'relationshipSet.relationships',
 				'relationshipSet.relationships.type', 'publisherSet.publishers',
 				'editionGroup', 'editionFormat', 'editionStatus',


### PR DESCRIPTION
Add authorCredits and their names to the list of properties to compare when doing a revision diff.