### PR TITLE
BB-780 and BB-862: Update Amazon ASIN validation regex and tests

### DIFF
--- a/test/validators/data.js
+++ b/test/validators/data.js
@@ -47,7 +47,7 @@ export const VALID_IDENTIFIERS = {
 
 export const IDENTIFIER_TYPES = [{
 	id: 1,
-	validationRegex: /^(?:B\d{2}\w{7}|\d{9}[X\d])$/
+	validationRegex: /^(?:B0[A-Z0-9]{8}|\d{9}[X\d])$/
 }];
 
 export const INVALID_IDENTIFIER = {...VALID_IDENTIFIERS, value: 'B076QRJV1'};

--- a/test/validators/test-identifier.js
+++ b/test/validators/test-identifier.js
@@ -42,6 +42,23 @@ function describeValidateIdentifierValueNoIdentifierTypes() {
 }
 
 function describeValidateIdentifierValueWithIdentifierTypes() {
+	it('should pass a valid newer-format ASIN', () => {
+		expect(() => validateIdentifierValue(
+			'B0CQKH14BB', 1, IDENTIFIER_TYPES
+		)).to.not.throw();
+	});
+
+	it('should pass a valid older-format ASIN', () => {
+		expect(() => validateIdentifierValue(
+			'B076KQRJV1', 1, IDENTIFIER_TYPES
+		)).to.not.throw();
+	});
+
+	it('should reject an ASIN that does not start with B0', () => {
+		expect(() => validateIdentifierValue(
+			'C0CQKH14BB', 1, IDENTIFIER_TYPES
+		)).to.throw(ValidationError);
+	});
 	it('should pass a non-empty string value that matches the validation regular expression', () => {
 		expect(() => validateIdentifierValue(
 			'B076KQRJV1', 1, IDENTIFIER_TYPES


### PR DESCRIPTION
This PR addresses the backend validation for [BB-780](https://tickets.metabrainz.org/browse/BB-780).

## Update
- Updated the `IDENTIFIER_TYPES` validation regex for Amazon ASINs from `^(?:B\d{2}\w{7}|\d{9}[X\d])$` to `^(?:B0[A-Z0-9]{8}|\d{9}[X\d])$`.
- This ensures modern, alphanumeric ASINs (like `B0CQKH14BB`) are correctly validated.

*Note: A companion PR for `bookbrainz-site` containing frontend test updates and the SQL migration script will be opened shortly.*

 ### TESTING
---
- [x] I have run the code and manually tested the changes
## AI usage
---
- [ ]  I have used AI in this PR (add more details below)
- [ ] I understand all the changes made in this PR
