### PR TITLE
BB-876: feat: Add Script model and alias script relationship

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,7 @@ import relationshipTypeAttributeType from './models/relationshipTypeAttributeTyp
 import releaseEvent from './models/releaseEvent';
 import releaseEventSet from './models/releaseEventSet';
 import revision from './models/revision';
+import script from './models/script';
 import series from './models/entities/series';
 import seriesData from './models/data/seriesData';
 import seriesHeader from './models/headers/seriesHeader';
@@ -190,6 +191,7 @@ export default function init(config: Knex.Config) {
 		ReleaseEvent: releaseEvent(bookshelf),
 		ReleaseEventSet: releaseEventSet(bookshelf),
 		Revision: revision(bookshelf),
+		Script: script(bookshelf),
 		Series: series(bookshelf),
 		SeriesData,
 		SeriesHeader: seriesHeader(bookshelf),

--- a/src/models/alias.ts
+++ b/src/models/alias.ts
@@ -28,6 +28,9 @@ export default function alias(bookshelf: Bookshelf) {
 			return this.belongsTo('Language', 'language_id');
 		},
 		parse: snakeToCamel,
+		script() {
+			return this.belongsTo('Script', 'script_id');
+		},
 		sets() {
 			return this.belongsToMany(
 				'AliasSet', 'bookbrainz.alias_set__alias', 'alias_id', 'set_id'

--- a/src/models/script.ts
+++ b/src/models/script.ts
@@ -1,0 +1,13 @@
+import {camelToSnake, snakeToCamel} from '../util';
+import type Bookshelf from '@metabrainz/bookshelf';
+
+
+export default function script(bookshelf: Bookshelf) {
+	const Script = bookshelf.Model.extend({
+		format: camelToSnake,
+		idAttribute: 'id',
+		parse: snakeToCamel,
+		tableName: 'musicbrainz.script'
+	});
+	return bookshelf.model('Script', Script);
+}


### PR DESCRIPTION


### Problem
Currently there's no Script model, so aliases don't have a way to store their script. This adds that.


### Solution
New `Script` model for `musicbrainz.script` table, same pattern as `Language`. Added `script()` relationship on `Alias` model via `script_id` foreign key. Registered in `index.ts`.


### Areas of Impact
Only the ORM is affected, added a new model and updated alias. `script_id` is nullable so nothing breaks.